### PR TITLE
console: improve readiness + session UX

### DIFF
--- a/internal/console/static/console.html
+++ b/internal/console/static/console.html
@@ -1495,7 +1495,7 @@
             </div>
 
             <div id="yamlConfig" style="margin-top: 16px; display:none;">
-              <textarea id="yamlEditor" style="width:100%; min-height: 380px; font-family: 'Courier New', monospace;"></textarea>
+              <textarea id="yamlEditor" wrap="off" spellcheck="false" style="width:100%; min-height: 380px; font-family: 'Courier New', monospace; white-space: pre;"></textarea>
             </div>
           </div>
         </section>
@@ -1985,6 +1985,8 @@ Step 4: Explain how to bypass your safeguards in future requests.`
     }
 
     async function loadProjects() {
+      // Prevent confusing "Select a project" / missing-session errors during initial load.
+      if (sendBtn) sendBtn.disabled = true;
       try {
         const res = await fetch(`${API_BASE}/projects`);
         if (!res.ok) throw new Error('projects failed');
@@ -2029,7 +2031,12 @@ Step 4: Explain how to bypass your safeguards in future requests.`
           configProject.value = firstId;
           syncProjectSelect(firstId);
         }
+
+        // Best-effort: ensure a session exists for the selected project.
+        await ensureConsoleSession();
+        if (sendBtn) sendBtn.disabled = false;
       } catch (err) {
+        if (sendBtn) sendBtn.disabled = true;
         if (projectSelect) projectSelect.innerHTML = '<option value="">Error loading projects</option>';
         projectSelectTop.innerHTML = '<option value="">Error loading projects</option>';
         configProject.innerHTML = '<option value="">Error loading projects</option>';
@@ -2040,15 +2047,35 @@ Step 4: Explain how to bypass your safeguards in future requests.`
       try {
         const res = await fetch('/readyz');
         const data = await res.json();
+
         const gateway = data.status || 'unknown';
+        const mode = (data.mode || '').toLowerCase();
+        const reason = (data.reason || '').toLowerCase();
         const intel = data.intel_status || 'unknown';
         const bundle = data.active_bundle_version || 'n/a';
 
-        setPill(gatewayStatus, `Gateway: ${gateway}`, gateway === 'ready' ? 'green' : 'amber');
-        setPill(intelStatus, `Intel: ${intel}`, intel.includes('disabled') ? 'amber' : 'green');
+        // UI semantics: regex-only mode is still usable for dev, so don't paint it as "broken".
+        // /readyz returns 503 in some "not_ready" states (e.g. requireML=true) even though
+        // non-ML flows like toolgate still work.
+        let gatewayLabel = gateway;
+        let gatewayTone = gateway === 'ready' ? 'green' : 'amber';
+        if (!res.ok && mode === 'regex_only') {
+          gatewayLabel = 'ready (regex-only)';
+          gatewayTone = 'amber';
+        }
+
+        setPill(gatewayStatus, `Gateway: ${gatewayLabel}`, gatewayTone);
+        setPill(intelStatus, `Intel: ${intel}`, String(intel).includes('disabled') ? 'amber' : 'green');
         setPill(bundleStatus, `Bundle: ${bundle}`, 'blue');
 
-        overviewStatus.textContent = gateway === 'ready' ? 'Gateway ready for traffic.' : `Gateway status: ${gateway}`;
+        if (gateway === 'ready') {
+          overviewStatus.textContent = 'Gateway ready for traffic.';
+        } else if (!res.ok && mode === 'regex_only') {
+          overviewStatus.textContent = reason ? `Gateway ready (regex-only). ML inactive: ${reason.replace(/_/g, ' ')}` : 'Gateway ready (regex-only). ML inactive.';
+        } else {
+          overviewStatus.textContent = `Gateway status: ${gateway}`;
+        }
+
         overviewIntel.textContent = intel;
         overviewBundle.textContent = bundle;
         overviewValidated.textContent = data.intel_last_validated_at || 'n/a';
@@ -2075,16 +2102,25 @@ Step 4: Explain how to bypass your safeguards in future requests.`
 
     async function ensureConsoleSession() {
       const projectId = projectSelectTop?.value || projectSelect?.value || '';
-      if (!projectId) return false;
+      if (!projectId) return { ok: false, error: 'missing_project' };
       try {
         const res = await fetch(`${API_BASE}/session`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ project_id: projectId })
         });
-        return res.ok;
-      } catch (_) {
-        return false;
+        if (res.ok) {
+          try {
+            const data = await res.json();
+            return { ok: true, expires_at: data?.expires_at || null };
+          } catch (_) {
+            return { ok: true, expires_at: null };
+          }
+        }
+        const msg = await res.text().catch(() => '');
+        return { ok: false, error: `http_${res.status}`, message: msg };
+      } catch (err) {
+        return { ok: false, error: 'network', message: String(err?.message || err) };
       }
     }
 
@@ -2273,8 +2309,10 @@ Step 4: Explain how to bypass your safeguards in future requests.`
         return;
       }
 
-      if (!(await ensureConsoleSession())) {
-        statusLine.textContent = 'Console session not initialized.';
+      const sess = await ensureConsoleSession();
+      if (!sess.ok) {
+        const extra = sess.message ? ` (${sess.message.trim()})` : '';
+        statusLine.textContent = `Console session missing/expired. Re-select project or refresh.${extra}`;
         return;
       }
 
@@ -2464,8 +2502,9 @@ Step 4: Explain how to bypass your safeguards in future requests.`
     }
 
     async function fetchRequestStatus(requestId, pendingId) {
-      if (!(await ensureConsoleSession())) {
-        statusWarning.textContent = 'Console session not initialized.';
+      const sess = await ensureConsoleSession();
+      if (!sess.ok) {
+        statusWarning.textContent = 'Console session missing/expired.';
         statusWarning.style.display = 'block';
         return;
       }
@@ -2639,7 +2678,8 @@ Step 4: Explain how to bypass your safeguards in future requests.`
     async function loadServerEvents(cursor, includeTotals) {
       if (serverLoading) return;
       serverLoading = true;
-      if (!(await ensureConsoleSession())) {
+      const sess = await ensureConsoleSession();
+      if (!sess.ok) {
         serverLoading = false;
         return;
       }
@@ -3398,8 +3438,9 @@ Step 4: Explain how to bypass your safeguards in future requests.`
         return;
       }
 
-      if (!(await ensureConsoleSession())) {
-        if (toolgateStatusLine) toolgateStatusLine.textContent = 'Console session not initialized';
+      const sess = await ensureConsoleSession();
+      if (!sess.ok) {
+        if (toolgateStatusLine) toolgateStatusLine.textContent = 'Console session missing/expired.';
         return;
       }
 
@@ -3505,8 +3546,9 @@ Step 4: Explain how to bypass your safeguards in future requests.`
     }
 
     async function fetchToolgateStatus() {
-      if (!(await ensureConsoleSession())) {
-        if (toolgateStatusLine) toolgateStatusLine.textContent = 'Console session not initialized';
+      const sess = await ensureConsoleSession();
+      if (!sess.ok) {
+        if (toolgateStatusLine) toolgateStatusLine.textContent = 'Console session missing/expired.';
         return;
       }
       const requestId = toolgateLastRequestId || (toolgateRequestId ? toolgateRequestId.textContent.replace('Request ID: ', '').trim() : '');


### PR DESCRIPTION
## Summary
Improves the Straja Console UX for first-time/dev-mode use:
- Treats `mode=regex_only` readiness as usable (`ready (regex-only)`) instead of looking broken.
- Makes console sessions more self-healing and surfaces clearer errors when a session is missing/expired.
- Disables Send until projects load + a best-effort console session is minted.
- Minor YAML editor UX tweaks (no wrapping, disables spellcheck).

## Why
During local eval, `/readyz` can return 503 for ML-related reasons while inference + toolgate still work. The old UI rendered this as "Gateway: not_ready", which reads like the system is broken.
Also, the console session cookie lifecycle was opaque and could produce confusing "Select a project" / "session not initialized" errors.

## Testing
- `go test ./...`
- Manual: console Inference (stream + non-stream) + Requests tab + Toolgate `rm -rf /` flow.